### PR TITLE
Be more specific in error message when exiting with `1` (present Erlang/OTP version considered)

### DIFF
--- a/src/geas_api.hrl
+++ b/src/geas_api.hrl
@@ -766,7 +766,7 @@ check_window_vs_semver_frame(_Window, _Frame) % No frame set
 %% @end
 %%-------------------------------------------------------------------------
 format_error(0) ->  "Success" ;
-format_error(1) ->  "Current Erlang/OTP release is incompatible with project release window" ; 
+format_error(1) ->  "The Erlang/OTP version used for analysis (" ++ get_current_erlang_version() ++ ") is incompatible with the project's release window" ;
 format_error(2) ->  "Release window do not match the required semver version range" ;
 format_error(3) ->  "Beam files are incompatible with current Erlang/OTP release (May need recompilation)" ;
 format_error(4) ->  "Maximum opcode is higher in Beam files (May need recompilation)" ;


### PR DESCRIPTION
Briefly mentioned in the description of https://github.com/crownedgrouse/geas_rebar3/issues/9.

The pull request's goal is to move the error message from

```console
===> Current Erlang/OTP release is incompatible with project release window
```

to e.g.

```console
===> The Erlang/OTP version used for analysis (26.1.1) is incompatible with the project's release window
```