### PR TITLE
Prevent crash when min. is higher than max. in expected range

### DIFF
--- a/src/geas_api.hrl
+++ b/src/geas_api.hrl
@@ -382,7 +382,7 @@ compat(RootDir, print, Config) ->
    lists:foreach(fun({LD, AD, RD, FD}) -> io:format("   ~-10s ~-10s ~-10s ~-20s ~20s~n",[LD, AD, RD, FD, get_version(FD)]) end, D),
    io:format("~80s~n",[string:copies("-",80)]),
    io:format("   ~-10s ~-10s ~-10s ~-20s ~20s~n",[MinGlob , ArchGlob, MaxGlob, "Global project", get_version(Project)]),
-   Rels = w2l({?GEAS_MIN_REL, MinGlob, MaxGlob, ?GEAS_MAX_REL}),
+   Rels = w2l({?GEAS_MIN_REL, MinGlob, MaxGlob, ?GEAS_MAX_REL}), % Might return empty list, if MinGlob is "higher" than MaxGlob.
    io:format("~n",[]),
    % Always display current version detected and patches found
    Current = get_current_erlang_version(),
@@ -706,6 +706,8 @@ get_erlang_compat_beam(File) ->
 %% @doc Check current Erlang release against project release window
 %% @end
 %%-------------------------------------------------------------------------
+check_current_rel_vs_window(_Current, [] = _Window) ->
+   throw(5);
 check_current_rel_vs_window(Current, Window)
    -> 
    Start = hd(Window),
@@ -770,5 +772,5 @@ format_error(1) ->  "Current Erlang/OTP release is incompatible with project rel
 format_error(2) ->  "Release window do not match the required semver version range" ;
 format_error(3) ->  "Beam files are incompatible with current Erlang/OTP release (May need recompilation)" ;
 format_error(4) ->  "Maximum opcode is higher in Beam files (May need recompilation)" ;
-format_error(5) ->  "Release window do not match the required semver version frame" ;
+format_error(5) ->  "The release window does not match the required SemVer version frame" ;
 format_error(_) ->  "Unexpected exit code".

--- a/src/geas_semver.erl
+++ b/src/geas_semver.erl
@@ -45,6 +45,8 @@ versionize(V) -> samovar:versionize(V).
 %%-------------------------------------------------------------------------
 -spec l2s(list()) -> {ok, list()} | {error, atom()}.
 
+l2s([]) ->
+	{ok, []};
 l2s(L) when is_list(L)
 	-> 
 	try


### PR DESCRIPTION
The project I used `geas` on reports, in its analysis

```console
   R15                   26.1       Geas database                      2.7.14
---Min--------Arch-------Max----------------------------------------------------
   17.0                  20.3       parse_trans                         3.3.1
```

and `geas_api.hrl`'s `compat/2` will eventually calculate:

* `MinGlob` as `25.0` (because I'm using `lists:uniq/1`, for example)
* `MaxGlob` as `20.3` (because of the above)
  * `MaxGlob` is the lowest version among the highest calculated (as per the current code)

This, in turn, means (using the default `geas` options), `geas_semver:l2s/1` will throw because of a call to `hd` in `geas_semver:seq2range/1`.

---

This pr aims at preventing this by considering it is possible/valid to have such an output as the one first shown, though it shouldn't affect the application's behaviour by crashing.

At the same time we `throw(5)`, which results in

```console
===> The release window does not match the required SemVer version frame
```

which seems appropriate in this case (we also do a minor tweak on the error message).

## Further considerations

Mind you the output for `T : ` will not be followed by any text, but this might be undesirable. Lemme know and I can adapt the pr.